### PR TITLE
Update Docs for Webpack 4 Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ module.exports = {
               }
             }
           }
-        ]
+        ],
+        type: "javascript/auto"
       }
     ]
   }


### PR DESCRIPTION
The default config in the readme doesn't actually work out of the box with Webpack 4 (haven't tried with others)

Specifying the output type on the loader config fixes it right up.

Here's the error for googling

```
ERROR in ./src/net/Internals/transportSchema/meta.schema.json
Module parse failed: Unexpected token ' in JSON at position 0 while parsing near ''use strict';
var va...'
File was processed with these loaders:
 * ./node_modules/ajv-json-loader/index.js
You may need an additional loader to handle the result of these loaders.
SyntaxError: Unexpected token ' in JSON at position 0 while parsing near ''use strict';
```